### PR TITLE
Fix error when using PHP 8.0

### DIFF
--- a/LibSkin/src/Himbeer/LibSkin/SkinConverter.php
+++ b/LibSkin/src/Himbeer/LibSkin/SkinConverter.php
@@ -49,7 +49,7 @@ final class SkinConverter {
 	 * @throws Exception
 	 */
 	public static function imageToSkinData($image, bool $destroyImage): string {
-		if (get_resource_type($image) !== "gd") {
+		if (get_class($image) !== "GdImage") {
 			throw new Exception("1st parameter must be a GD image resource");
 		}
 		$size = imagesx($image) * imagesy($image) * 4;


### PR DESCRIPTION
Fix "Error: get_resource_type(): Argument #1 ($resource) must be of type resource, GdImage given" error when using PocketMine-MP with PHP 8.0